### PR TITLE
fix: export mollieProvider and stripeProvider from main package

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,8 @@
 
 export { billingPlugin } from './plugin/index.js'
+export { mollieProvider, stripeProvider } from './providers/index.js'
 export type { BillingPluginConfig, CustomerInfoExtractor } from './plugin/config.js'
 export type { Invoice, Payment, Refund } from './plugin/types/index.js'
+export type { PaymentProvider, ProviderData } from './providers/types.js'
+export type { MollieProviderConfig } from './providers/mollie.js'
+export type { StripeProviderConfig } from './providers/stripe.js'


### PR DESCRIPTION
- Add re-exports for mollieProvider and stripeProvider in src/index.ts
- Export related provider types: PaymentProvider, ProviderData
- Export provider config types: MollieProviderConfig, StripeProviderConfig
- Resolves issue where providers were not accessible despite being documented

Fixes #14