### PR TITLE
chore: update Claude Code workflows to claude-code-action v1

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -7,69 +7,50 @@ on:
     # paths:
     #   - "src/**/*.ts"
     #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
 
 jobs:
   claude-review:
     # Only allow bvdaakster to trigger reviews
     if: github.event.pull_request.user.login == 'bvdaakster'
-    
+
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
       id-token: write
-    
+      actions: read # Lets Claude read CI results on the PR
+
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
-          # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4.1)
-          # model: "claude-opus-4-1-20250805"
+          # Providing `prompt` puts the action in automation mode, so no
+          # @claude mention is needed. track_progress posts a tracking comment
+          # that is updated as the review runs.
+          track_progress: true
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
 
-          # Direct prompt for automated review (no @claude mention needed)
-          direct_prompt: |
-            Please review this pull request and provide feedback on:
+            Review this pull request and provide feedback on:
             - Code quality and best practices
             - Potential bugs or issues
             - Performance considerations
-            - Security concerns
+            - Security concerns, especially around payment provider integrations
+              and webhook handling
             - Test coverage
-            
+            - Whether a changeset is needed for user-facing changes
+
             Be constructive and helpful in your feedback.
 
-          # Optional: Use sticky comments to make Claude reuse the same comment on subsequent pushes to the same PR
-          # use_sticky_comment: true
-          
-          # Optional: Customize review based on file types
-          # direct_prompt: |
-          #   Review this PR focusing on:
-          #   - For TypeScript files: Type safety and proper interface usage
-          #   - For API endpoints: Security, input validation, and error handling
-          #   - For React components: Performance, accessibility, and best practices
-          #   - For tests: Coverage, edge cases, and test quality
-          
-          # Optional: Different prompts for different authors
-          # direct_prompt: |
-          #   ${{ github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR' && 
-          #   'Welcome! Please review this PR from a first-time contributor. Be encouraging and provide detailed explanations for any suggestions.' ||
-          #   'Please provide a thorough code review focusing on our coding standards and best practices.' }}
-          
-          # Optional: Add specific tools for running tests or linting
-          # allowed_tools: "Bash(npm run test),Bash(npm run lint),Bash(npm run typecheck)"
-          
-          # Optional: Skip review for certain conditions
-          # if: |
-          #   !contains(github.event.pull_request.title, '[skip-review]') &&
-          #   !contains(github.event.pull_request.title, '[WIP]')
-
+          claude_args: |
+            --allowedTools "Bash(pnpm install),Bash(pnpm lint),Bash(pnpm typecheck),Bash(pnpm test:int)"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -19,46 +19,25 @@ jobs:
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pull-requests: read
-      issues: read
+      contents: write
+      pull-requests: write
+      issues: write
       id-token: write
-      actions: read # Required for Claude to read CI results on PRs
+      actions: read # Lets Claude read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
-          # This is an optional setting that allows Claude to read CI results on PRs
-          additional_permissions: |
-            actions: read
-          
-          # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4.1)
-          # model: "claude-opus-4-1-20250805"
-          
-          # Optional: Customize the trigger phrase (default: @claude)
-          # trigger_phrase: "/claude"
-          
-          # Optional: Trigger when specific user is assigned to an issue
-          # assignee_trigger: "claude-bot"
-          
-          # Optional: Allow Claude to run specific commands
-          # allowed_tools: "Bash(npm install),Bash(npm run build),Bash(npm run test:*),Bash(npm run lint:*)"
-          
-          # Optional: Add custom instructions for Claude to customize its behavior for your project
-          # custom_instructions: |
-          #   Follow our coding standards
-          #   Ensure all new code has tests
-          #   Use TypeScript for new files
-          
-          # Optional: Custom environment variables for Claude
-          # claude_env: |
-          #   NODE_ENV: test
-
+          # Everything else (model, turns, tools, system prompt) goes through
+          # claude_args using Claude Code CLI flag syntax.
+          claude_args: |
+            --allowedTools "Bash(pnpm install),Bash(pnpm build),Bash(pnpm lint),Bash(pnpm lint:fix),Bash(pnpm typecheck),Bash(pnpm test:int)"
+            --append-system-prompt "This is a PayloadCMS plugin (pnpm + TypeScript). Keep the public API in src/index.ts and src/exports/* stable, add a changeset for user-facing changes, and run pnpm typecheck and pnpm lint before finishing."

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xtr-dev/payload-billing",
-  "version": "0.1.28",
+  "version": "0.1.29",
   "description": "PayloadCMS plugin for billing and payment provider integrations with tracking and local testing",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
Both Claude workflows were still pinned to `anthropics/claude-code-action@beta` and using inputs that v1 removed, so they would fail (or silently ignore the review prompt) on the current action.

## Changes

**`.github/workflows/claude.yml`** (@claude mentions)
- `anthropics/claude-code-action@beta` → `@v1`
- Dropped `additional_permissions` (removed in v1); `actions: read` now lives in the job's `permissions` block
- Added `claude_args` with `--allowedTools` scoped to this repo's pnpm scripts (`install`, `build`, `lint`, `lint:fix`, `typecheck`, `test:int`) and an `--append-system-prompt` noting the plugin's public API surface and changeset convention
- Removed the block of stale commented-out options (including the `claude-opus-4-1` model hint)

**`.github/workflows/claude-code-review.yml`** (automatic PR review)
- `@beta` → `@v1`
- `direct_prompt` → `prompt`, which is what puts the action in automation mode in v1 — this input was being ignored entirely on v1
- Added `track_progress: true` so the review posts a single tracking comment that updates as it runs, instead of the old sticky-comment option
- Prompt now includes `REPO` / `PR NUMBER` context per the v1 automation pattern, plus review points specific to this plugin (payment provider integrations, webhook handling, changesets)
- Removed the stale commented-out option blocks

**Both**
- `permissions`: `contents`/`pull-requests`/`issues` raised from `read` to `write` — v1 needs write to post comments and push changes
- `actions/checkout` v4 → v7

The `bvdaakster`-only gate on the review workflow and the existing trigger sets are unchanged. `pr-version-check.yml` and `version-and-publish.yml` were left alone.

## Verification

Both files parse as valid YAML. Input mappings follow the [v0 → v1 migration guide](https://github.com/anthropics/claude-code-action/blob/main/docs/migration-guide.md); permission requirements follow the action's setup docs. End-to-end behaviour can only be confirmed once the workflows run on a PR — this one will exercise the review workflow if `CLAUDE_CODE_OAUTH_TOKEN` is still valid.

---
_Generated by [Claude Code](https://claude.ai/code/session_01V4RyqNLpzCXLbczX4tUmrs)_