### PR TITLE
Rebase onto current origin/main and bump version to 0.1.30 so pr-version-check.yml doesn't compare equal against main's already-merged 0.1.29

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,8 @@ The test provider requires no additional dependencies.
 
 ```typescript
 import { buildConfig } from 'payload'
-import { billingPlugin, stripeProvider } from '@xtr-dev/payload-billing'
+import { billingPlugin } from '@xtr-dev/payload-billing'
+import { stripeProvider } from '@xtr-dev/payload-billing/stripe'
 
 export default buildConfig({
   // ... your config
@@ -131,7 +132,7 @@ Full-featured credit card processing with support for multiple payment methods, 
 **Configuration:**
 
 ```typescript
-import { stripeProvider } from '@xtr-dev/payload-billing'
+import { stripeProvider } from '@xtr-dev/payload-billing/stripe'
 
 stripeProvider({
   secretKey: string          // Required: Stripe secret key (sk_test_... or sk_live_...)
@@ -162,7 +163,7 @@ European payment service provider supporting iDEAL, SEPA, Bancontact, and other 
 **Configuration:**
 
 ```typescript
-import { mollieProvider } from '@xtr-dev/payload-billing'
+import { mollieProvider } from '@xtr-dev/payload-billing/mollie'
 
 mollieProvider({
   apiKey: string           // Required: Mollie API key (test_... or live_...)
@@ -266,7 +267,8 @@ testProvider({
 Minimal configuration with a single provider:
 
 ```typescript
-import { billingPlugin, stripeProvider } from '@xtr-dev/payload-billing'
+import { billingPlugin } from '@xtr-dev/payload-billing'
+import { stripeProvider } from '@xtr-dev/payload-billing/stripe'
 
 billingPlugin({
   providers: [
@@ -283,6 +285,10 @@ billingPlugin({
 Use multiple payment providers simultaneously:
 
 ```typescript
+import { billingPlugin, testProvider } from '@xtr-dev/payload-billing'
+import { stripeProvider } from '@xtr-dev/payload-billing/stripe'
+import { mollieProvider } from '@xtr-dev/payload-billing/mollie'
+
 billingPlugin({
   providers: [
     stripeProvider({
@@ -1081,6 +1087,8 @@ const createPayment = async (
 
 1. **Always use webhook secrets in production:**
    ```typescript
+   import { stripeProvider } from '@xtr-dev/payload-billing/stripe'
+
    stripeProvider({
      secretKey: process.env.STRIPE_SECRET_KEY!,
      webhookSecret: process.env.STRIPE_WEBHOOK_SECRET!  // Required

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xtr-dev/payload-billing",
-  "version": "0.1.29",
+  "version": "0.1.30",
   "description": "PayloadCMS plugin for billing and payment provider integrations with tracking and local testing",
   "license": "MIT",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,16 @@
       "import": "./src/exports/rsc.tsx",
       "types": "./src/exports/rsc.tsx",
       "default": "./src/exports/rsc.tsx"
+    },
+    "./stripe": {
+      "import": "./src/exports/stripe.ts",
+      "types": "./src/exports/stripe.ts",
+      "default": "./src/exports/stripe.ts"
+    },
+    "./mollie": {
+      "import": "./src/exports/mollie.ts",
+      "types": "./src/exports/mollie.ts",
+      "default": "./src/exports/mollie.ts"
     }
   },
   "main": "./src/index.ts",
@@ -139,6 +149,16 @@
         "import": "./dist/exports/rsc.js",
         "types": "./dist/exports/rsc.d.ts",
         "default": "./dist/exports/rsc.js"
+      },
+      "./stripe": {
+        "import": "./dist/exports/stripe.js",
+        "types": "./dist/exports/stripe.d.ts",
+        "default": "./dist/exports/stripe.js"
+      },
+      "./mollie": {
+        "import": "./dist/exports/mollie.js",
+        "types": "./dist/exports/mollie.d.ts",
+        "default": "./dist/exports/mollie.js"
       }
     },
     "main": "./dist/index.js",

--- a/src/exports/mollie.ts
+++ b/src/exports/mollie.ts
@@ -1,0 +1,2 @@
+export { mollieProvider } from '../providers/mollie'
+export type { MollieProviderConfig } from '../providers/mollie'

--- a/src/exports/stripe.ts
+++ b/src/exports/stripe.ts
@@ -1,0 +1,2 @@
+export { stripeProvider } from '../providers/stripe'
+export type { StripeProviderConfig } from '../providers/stripe'

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,21 @@
 export { billingPlugin } from './plugin/index'
 export type { BillingPluginConfig, CustomerInfoExtractor, AdvancedTestProviderConfig } from './plugin/config'
 export type { Invoice, Payment, Refund } from './plugin/types/index'
-export type { PaymentProvider, ProviderData } from './providers/types'
+export type { PaymentProvider, ProviderData, InitPayment } from './providers/types'
+
+import type { Invoice as InvoiceType } from './plugin/types/invoices'
+import type { Payment as PaymentType } from './plugin/types/payments'
+import type { Refund as RefundType } from './plugin/types/refunds'
+
+// Reusable field-level types, derived from the collection types above so they
+// can't drift from the shapes they describe.
+export type PaymentStatus = PaymentType['status']
+export type InvoiceStatus = InvoiceType['status']
+export type RefundStatus = RefundType['status']
+export type RefundReason = NonNullable<RefundType['reason']>
+export type Address = NonNullable<InvoiceType['billingAddress']>
+export type InvoiceItem = InvoiceType['items'][number]
+export type CustomerInfo = NonNullable<InvoiceType['customerInfo']>
 
 // Export logging utilities
 export { getPluginLogger, createContextLogger } from './utils/logger'


### PR DESCRIPTION
Reviewer caught that the previous 0.1.28→0.1.29 bump was checked against a stale local main; origin/main had already merged PR #32 bumping to 0.1.29 for the same reason (pr-version-check.yml fails a PR whose version equals main's). Rebased this branch onto current origin/main and bumped package.json to 0.1.30. The README/stripe/mollie export-map fix itself is unchanged from the previously-verified commit — only the version and the base commit moved.