### PR TITLE
Fix remaining TS2722 in dev/invoice-number.spec.ts by optional-chaining payload.db.destroy()

### DIFF
--- a/README.md
+++ b/README.md
@@ -476,7 +476,7 @@ Generate and manage invoices with line items and customer information.
 ```typescript
 {
   id: string | number
-  number: string                        // Auto-generated (INV-YYYYMMDD-XXXX)
+  number: string                        // Auto-generated (INV-<unix-ms-timestamp>, e.g. INV-1755289904123)
   customer?: string                     // Customer relationship (if configured)
   customerInfo: {
     name: string

--- a/dev/invoice-number.spec.ts
+++ b/dev/invoice-number.spec.ts
@@ -1,0 +1,52 @@
+import type { Payload } from 'payload'
+
+import config from '@payload-config'
+import { getPayload } from 'payload'
+import { afterAll, beforeAll, describe, expect, test } from 'vitest'
+
+let payload: Payload
+
+afterAll(async () => {
+  await payload.db.destroy()
+})
+
+beforeAll(async () => {
+  payload = await getPayload({ config })
+})
+
+describe('Invoice number generation', () => {
+  test('auto-generates a number in the INV-<unix-ms-timestamp> form when none is provided', async () => {
+    const before = Date.now()
+
+    const invoice = await payload.create({
+      collection: 'invoices',
+      data: {
+        customerInfo: {
+          name: 'Jane Doe',
+          email: 'jane@example.com',
+        },
+        billingAddress: {
+          line1: '1 Example Street',
+          city: 'Example City',
+          postalCode: '1234AB',
+          country: 'NL',
+        },
+        items: [
+          {
+            description: 'Test item',
+            quantity: 1,
+            unitAmount: 1000,
+          },
+        ],
+      },
+    })
+
+    const after = Date.now()
+
+    expect(invoice.number).toMatch(/^INV-\d+$/)
+
+    const timestamp = Number(invoice.number.slice('INV-'.length))
+    expect(timestamp).toBeGreaterThanOrEqual(before)
+    expect(timestamp).toBeLessThanOrEqual(after)
+  })
+})

--- a/dev/invoice-number.spec.ts
+++ b/dev/invoice-number.spec.ts
@@ -7,7 +7,7 @@ import { afterAll, beforeAll, describe, expect, test } from 'vitest'
 let payload: Payload
 
 afterAll(async () => {
-  await payload.db.destroy()
+  await payload.db.destroy?.()
 })
 
 beforeAll(async () => {

--- a/dev/invoice-number.spec.ts
+++ b/dev/invoice-number.spec.ts
@@ -18,6 +18,9 @@ describe('Invoice number generation', () => {
   test('auto-generates a number in the INV-<unix-ms-timestamp> form when none is provided', async () => {
     const before = Date.now()
 
+    // number, status and currency are omitted on purpose: this test asserts that the
+    // beforeValidate hook fills `number` in, so the generated `Invoice` type (which marks
+    // them required) doesn't match what a caller actually has to pass.
     const invoice = await payload.create({
       collection: 'invoices',
       data: {
@@ -38,7 +41,7 @@ describe('Invoice number generation', () => {
             unitAmount: 1000,
           },
         ],
-      },
+      } as any,
     })
 
     const after = Date.now()

--- a/dev/payload-types.ts
+++ b/dev/payload-types.ts
@@ -233,7 +233,7 @@ export interface Payment {
 export interface Invoice {
   id: number;
   /**
-   * Invoice number (e.g., INV-001)
+   * Invoice number (auto-generated as INV-<unix-ms-timestamp>, e.g. INV-1755289904123, unless set explicitly)
    */
   number: string;
   /**

--- a/src/collections/invoices.ts
+++ b/src/collections/invoices.ts
@@ -25,7 +25,7 @@ export function createInvoicesCollection(pluginConfig: BillingPluginConfig): Col
       name: 'number',
       type: 'text',
       admin: {
-        description: 'Invoice number (e.g., INV-001)',
+        description: 'Invoice number (auto-generated as INV-<unix-ms-timestamp>, e.g. INV-1755289904123, unless set explicitly)',
       },
       index: true,
       required: true,

--- a/src/plugin/types/invoices.ts
+++ b/src/plugin/types/invoices.ts
@@ -4,7 +4,7 @@ import type { Id } from './id'
 export interface Invoice<TCustomer = unknown> {
   id: Id;
   /**
-   * Invoice number (e.g., INV-001)
+   * Invoice number (auto-generated as INV-<unix-ms-timestamp>, e.g. INV-1755289904123, unless set explicitly)
    */
   number: string;
   /**


### PR DESCRIPTION
A prior commit on this branch fixed the TS2322 on the create() data literal in dev/invoice-number.spec.ts but left a second, unrelated typecheck error in place: payload.db.destroy() failed TS2722 ("Cannot invoke an object which is possibly 'undefined'") because DatabaseAdapter.destroy is typed as optional.

This commit switches the call to optional chaining (payload.db.destroy?.()) rather than casting, since destroy genuinely may be absent on some adapters. Verified with a fresh pnpm install --frozen-lockfile + npx tsc --noEmit: the file's only remaining error is the TS2307 on @payload-config, which is the same pre-existing module-resolution gap already present in dev/int.spec.ts. npx vitest run dev/invoice-number.spec.ts still passes.