### PR TITLE
Widens peerDependencies.stripe from ^18.5.0 to also allow ^19-^22 after confirming the plugin's minimal Stripe surface (webhook signature verification, PaymentIntent.create) is unaffected across that span, and fixes the one real break the investigation found: an apiVersion type coupled to whichever version the installed SDK pins as "latest".

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "rimraf": "3.0.2",
     "sharp": "0.34.2",
     "sort-package-json": "^2.10.0",
-    "stripe": "^18.5.0",
+    "stripe": "^22.5.0",
     "tailwindcss": "^4.1.17",
     "tsc-alias": "^1.8.16",
     "typescript": "5.7.3",
@@ -114,7 +114,7 @@
   "peerDependencies": {
     "@mollie/api-client": "^3.7.0 || ^4.0.0",
     "payload": "^3.37.0",
-    "stripe": "^18.5.0"
+    "stripe": "^18.5.0 || ^19.0.0 || ^20.0.0 || ^21.0.0 || ^22.0.0"
   },
   "dependencies": {
     "zod": "^3.22.4"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -121,8 +121,8 @@ importers:
         specifier: ^2.10.0
         version: 2.15.1
       stripe:
-        specifier: ^18.5.0
-        version: 18.5.0(@types/node@22.18.1)
+        specifier: ^22.5.0
+        version: 22.5.0(@types/node@22.18.1)
       tailwindcss:
         specifier: ^4.1.17
         version: 4.1.17
@@ -4958,10 +4958,6 @@ packages:
     resolution: {integrity: sha512-D8NAthKSD7SGn748v+GLaaO6k08Mvpoqroa35PqIQC4gtUa8/Pb/k+r0m0NnGBVbHDP1gKZ2nVywqfMisRhV5A==}
     engines: {node: '>=18'}
 
-  qs@6.14.0:
-    resolution: {integrity: sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==}
-    engines: {node: '>=0.6'}
-
   quansync@0.2.11:
     resolution: {integrity: sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==}
 
@@ -5413,11 +5409,11 @@ packages:
   strip-literal@3.0.0:
     resolution: {integrity: sha512-TcccoMhJOM3OebGhSBEmp3UZ2SfDMZUEBdRA/9ynfLi8yYajyWX3JiXArcJt4Umh4vISpspkQIY8ZZoCqjbviA==}
 
-  stripe@18.5.0:
-    resolution: {integrity: sha512-Hp+wFiEQtCB0LlNgcFh5uVyKznpDjzyUZ+CNVEf+I3fhlYvh7rZruIg+jOwzJRCpy0ZTPMjlzm7J2/M2N6d+DA==}
-    engines: {node: '>=12.*'}
+  stripe@22.5.0:
+    resolution: {integrity: sha512-QVwMwriC0bbySx6R4dpsvJ0W//GojC1kwWVS6rPSoVqDUIZX4Hy3TaUrd2AZeXEAaKbfWIjQjvo3vKAReHZ0vQ==}
+    engines: {node: '>=18'}
     peerDependencies:
-      '@types/node': '>=12.x.x'
+      '@types/node': '>=18'
     peerDependenciesMeta:
       '@types/node':
         optional: true
@@ -11310,10 +11306,6 @@ snapshots:
 
   qs-esm@7.0.2: {}
 
-  qs@6.14.0:
-    dependencies:
-      side-channel: 1.1.0
-
   quansync@0.2.11: {}
 
   queue-lit@1.5.2: {}
@@ -11891,9 +11883,7 @@ snapshots:
     dependencies:
       js-tokens: 9.0.1
 
-  stripe@18.5.0(@types/node@22.18.1):
-    dependencies:
-      qs: 6.14.0
+  stripe@22.5.0(@types/node@22.18.1):
     optionalDependencies:
       '@types/node': 22.18.1
 

--- a/src/providers/stripe.ts
+++ b/src/providers/stripe.ts
@@ -19,13 +19,17 @@ const symbol = Symbol.for('@xtr-dev/payload-billing/stripe')
 export interface StripeProviderConfig {
   secretKey: string
   webhookSecret?: string
-  apiVersion?: Stripe.StripeConfig['apiVersion']
+  // string, not Stripe.StripeConfig['apiVersion']: that type is a single literal tied to
+  // whichever version the installed stripe SDK release happens to pin as "latest", so it
+  // breaks on every SDK bump that changes the pin rather than only on ones that matter here.
+  apiVersion?: string
   returnUrl?: string
   webhookUrl?: string
 }
 
-// Default API version for consistency
-const DEFAULT_API_VERSION: Stripe.StripeConfig['apiVersion'] = '2025-08-27.basil'
+// Pinned independently of the installed SDK's "latest" version so upgrading stripe doesn't
+// silently change what API version this plugin talks to.
+const DEFAULT_API_VERSION = '2025-08-27.basil'
 
 export const stripeProvider = (stripeConfig: StripeProviderConfig) => {
   // Validate required configuration at initialization
@@ -198,7 +202,9 @@ export const stripeProvider = (stripeConfig: StripeProviderConfig) => {
     onInit: async (payload: Payload) => {
       const { default: Stripe } = await import('stripe')
       const stripe = new Stripe(stripeConfig.secretKey, {
-        apiVersion: stripeConfig.apiVersion || DEFAULT_API_VERSION,
+        // Cast needed because the SDK's apiVersion type only accepts its own "latest" literal;
+        // Stripe's own docs say to pin an explicit version this way (stripe.com/docs/api/versioning).
+        apiVersion: (stripeConfig.apiVersion || DEFAULT_API_VERSION) as Stripe.StripeConfig['apiVersion'],
       })
       singleton.set(payload, stripe)
 


### PR DESCRIPTION
The reported gap: package.json's peerDependencies.stripe (^18.5.0) and devDependencies.stripe (^18.5.0) were both 4 majors behind npm's current stripe release (22.5.0), while the other two peers (@mollie/api-client, payload) already track current releases.

I treated the verdict's framing literally: it approved investigating and re-testing, not a predetermined range widening. So before touching the range I established a real baseline (tsc --noEmit with stripe@18.5.0 installed: 23 pre-existing, unrelated errors — all in dev/app template scaffolding and two known TS gaps, none touching stripe.ts) and then bumped only the devDependency to stripe@22.5.0 to see what actually broke.

Exactly one new error appeared: `src/providers/stripe.ts(28,7): error TS2322: Type '"2025-08-27.basil"' is not assignable to type '"2026-07-29.dahlia"'`. Root cause: stripe-node types `StripeConfig.apiVersion` as `LatestApiVersion`, a single string literal equal to whatever that exact SDK release pins as "latest" — not a union of historically valid versions. This plugin's `DEFAULT_API_VERSION` was typed against that same literal, so it only ever type-checked because 18.5.0 happens to pin the identical string this plugin hardcodes. That's a coincidence, not a guarantee — the same break would have hit any stripe release (even a minor within the old ^18.5.0 range) that changed its pinned literal. Fixed by loosening the plugin's own `apiVersion` field and constant to `string` and casting only at the `new Stripe()` call site, which is what Stripe's own StripeConfig.apiVersion doc comment recommends for pinning a non-latest version.

Before trusting that this was the *only* real difference, I read every major-version changelog entry between 19.0.0 and 22.0.0 (stripe-node ships a migration guide and ⚠️-prefixed breaking-change markers per major) looking specifically for anything touching the plugin's actual surface: the `new Stripe()` constructor pattern (already using `new`, so v22's removal of callable-without-new doesn't apply), `stripe.webhooks.constructEvent`, `PaymentIntent.create`'s params (amount, currency, description, metadata, automatic_payment_methods, return_url), and the `Charge`/`Event` fields read in the webhook handler (payment_intent, id, amount_refunded, amount, type). Nothing broke any of that — the breaking changes across 19-22 are in V2 API namespaces, decimal-string field types on resources this plugin never touches (InvoiceItem, Price, Issuing), and TypeScript-only reorganization, none of which this integration exercises.

I didn't stop at static analysis given the security weight of webhook verification here (r9iov30: a webhook must be verified before it changes anything). I wrote a throwaway offline script against the installed stripe@22.5.0 package exercising the exact call this plugin makes: generated a valid test signature and confirmed `constructEvent` accepts it and returns the right event type; tampered the signature and confirmed it correctly throws `StripeSignatureVerificationError`; and called `paymentIntents.create` with the plugin's exact param shape (including `return_url`) to confirm it's still accepted through to Stripe's network/auth layer with no client-side param validation error. All three passed identically to what 18.5.0 does.

With the one real blocker fixed and the rest of the range checked against actual changelog content plus targeted runtime verification, I widened peerDependencies.stripe to `^18.5.0 || ^19.0.0 || ^20.0.0 || ^21.0.0 || ^22.0.0` — matching the multi-range style this file already uses for @mollie/api-client — and bumped devDependencies.stripe to ^22.5.0 so the installed/tested version now sits at the new ceiling. Final tsc --noEmit output is byte-identical to the pre-change baseline: zero new errors.

What I did not do: run this against a live Stripe account (no test credentials available in this environment) or exercise the plugin through Payload's own test harness, since dev/int.spec.ts on this branch point is unrelated template scaffolding with no billing-plugin coverage (a gap already tracked by several open branches). The verification here is static (full changelog read across 4 majors) plus targeted runtime checks of the exact calls this plugin makes, not an end-to-end integration run.