### PR TITLE
disabled keeps the billing collection schemas instead of dropping them, so turning the plugin off no longer risks a migration wiping payments history. Hooks, endpoints, and admin views stay off, and onInit is not wrapped.

### DIFF
--- a/README.md
+++ b/README.md
@@ -945,8 +945,11 @@ type BillingPluginConfig = {
   }
   customerRelationSlug?: string
   customerInfoExtractor?: CustomerInfoExtractor
+  disabled?: boolean
 }
 ```
+
+Setting `disabled: true` keeps the billing collection schemas registered to preserve stored billing data, but denies all collection access, hides their admin views, and skips their hooks, endpoints, and provider wiring.
 
 ### Provider Types
 

--- a/dev/plugin-config.spec.ts
+++ b/dev/plugin-config.spec.ts
@@ -1,0 +1,127 @@
+import type { Config, Payload } from 'payload'
+import { describe, expect, test, vi } from 'vitest'
+
+import billingPlugin, { useBillingPlugin } from '../src/plugin'
+import { testProvider } from '../src/providers/test'
+
+const makeConfig = (overrides: Partial<Config> = {}): Config =>
+  ({ collections: [], ...overrides }) as Config
+
+const findCollection = (config: Config, slug: string) =>
+  config.collections?.find((collection) => collection.slug === slug)
+
+const findField = (config: Config, collectionSlug: string, fieldName: string) => {
+  const collection = findCollection(config, collectionSlug)
+  return (collection?.fields as any[] | undefined)?.find((field) => field.name === fieldName)
+}
+
+describe('billingPlugin config transform', () => {
+  test('appends the billing collections to existing ones instead of replacing them', () => {
+    const config = makeConfig({ collections: [{ slug: 'posts', fields: [] }] })
+
+    const result = billingPlugin()(config)
+
+    expect(result.collections).toHaveLength(4)
+    expect(result.collections?.map((collection) => collection.slug)).toEqual([
+      'posts',
+      'payments',
+      'invoices',
+      'refunds',
+    ])
+  })
+
+  test('propagates a payments slug override into the invoices and refunds relationships', () => {
+    const config = makeConfig()
+
+    const result = billingPlugin({ collections: { payments: 'orders' } })(config)
+
+    expect(findCollection(result, 'orders')).toBeDefined()
+    expect(findField(result, 'invoices', 'payment')?.relationTo).toBe('orders')
+    expect(findField(result, 'refunds', 'payment')?.relationTo).toBe('orders')
+  })
+
+  test('resolves the string and object forms of CollectionExtension identically', () => {
+    const slugsFor = (result: Config) => ({
+      paymentsSlug: findCollection(result, 'orders')?.slug,
+      invoiceRelation: findField(result, 'invoices', 'payment')?.relationTo,
+      refundRelation: findField(result, 'refunds', 'payment')?.relationTo,
+    })
+
+    const withString = billingPlugin({ collections: { payments: 'orders' } })(makeConfig())
+    const withObject = billingPlugin({ collections: { payments: { slug: 'orders' } } })(makeConfig())
+
+    expect(slugsFor(withString)).toEqual(slugsFor(withObject))
+    expect(slugsFor(withString).paymentsSlug).toBe('orders')
+  })
+
+  test('applies extend and keeps the base collection fields', () => {
+    const config = makeConfig()
+
+    const result = billingPlugin({
+      collections: {
+        payments: {
+          slug: 'orders',
+          extend: (collectionConfig) => ({
+            ...collectionConfig,
+            fields: [...collectionConfig.fields, { name: 'x', type: 'text' }],
+          }),
+        },
+      },
+    })(config)
+
+    const payments = findCollection(result, 'orders')
+    const fieldNames = (payments?.fields as any[]).map((field) => field.name)
+    expect(fieldNames).toContain('x')
+    expect(fieldNames).toContain('providerId')
+  })
+
+  test('disabled is a true no-op: collections and onInit identity are untouched', () => {
+    const onInit = async () => {}
+    const config = makeConfig({ collections: [{ slug: 'posts', fields: [] }], onInit })
+
+    const result = billingPlugin({ disabled: true })(config)
+
+    expect(result.collections).toHaveLength(1)
+    expect(result.onInit).toBe(onInit)
+  })
+
+  test("runs the consumer's existing onInit first, before the plugin becomes available", async () => {
+    const order: string[] = []
+    const fakePayload = {} as Payload
+    const config = makeConfig({
+      onInit: async (payload) => {
+        order.push('consumer')
+        expect(useBillingPlugin(payload)).toBeUndefined()
+      },
+    })
+
+    const result = billingPlugin()(config)
+    await result.onInit!(fakePayload)
+
+    expect(order).toEqual(['consumer'])
+    expect(useBillingPlugin(fakePayload)).toBeDefined()
+  })
+
+  test('registers providers by key and tolerates holes from disabled providers', async () => {
+    vi.useFakeTimers()
+    try {
+      const provider = testProvider({ enabled: true })!
+      const onConfigSpy = vi.spyOn(provider, 'onConfig')
+      const config = makeConfig()
+      const pluginConfig = { providers: [undefined, provider, testProvider({ enabled: false }), null] }
+
+      const result = billingPlugin(pluginConfig)(config)
+
+      expect(onConfigSpy).toHaveBeenCalledTimes(1)
+      expect(onConfigSpy).toHaveBeenCalledWith(config, pluginConfig)
+
+      const fakePayload = {} as Payload
+      await expect(result.onInit!(fakePayload)).resolves.not.toThrow()
+
+      const plugin = useBillingPlugin(fakePayload)
+      expect(Object.keys(plugin!.providerConfig)).toEqual(['test'])
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})

--- a/dev/plugin-config.spec.ts
+++ b/dev/plugin-config.spec.ts
@@ -75,13 +75,24 @@ describe('billingPlugin config transform', () => {
     expect(fieldNames).toContain('providerId')
   })
 
-  test('disabled is a true no-op: collections and onInit identity are untouched', () => {
+  test('disabled keeps billing collections and does not wrap onInit', () => {
     const onInit = async () => {}
     const config = makeConfig({ collections: [{ slug: 'posts', fields: [] }], onInit })
 
     const result = billingPlugin({ disabled: true })(config)
 
-    expect(result.collections).toHaveLength(1)
+    expect(result.collections?.map((collection) => collection.slug)).toEqual([
+      'posts',
+      'payments',
+      'invoices',
+      'refunds',
+    ])
+    for (const slug of ['payments', 'invoices', 'refunds']) {
+      const collection = findCollection(result, slug)
+      expect((collection?.fields as any[]).length).toBeGreaterThan(0)
+      expect(collection?.hooks).toEqual({})
+      expect(collection?.endpoints).toBe(false)
+    }
     expect(result.onInit).toBe(onInit)
   })
 

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -1,6 +1,6 @@
 import { createInvoicesCollection, createPaymentsCollection, createRefundsCollection } from '../collections/index'
 import type { BillingPluginConfig } from './config'
-import type { Config, Payload } from 'payload'
+import type { CollectionConfig, Config, Payload } from 'payload'
 import { createSingleton } from './singleton'
 import type { PaymentProvider } from '../providers/index'
 
@@ -15,17 +15,42 @@ type BillingPlugin = {
 
 export const useBillingPlugin = (payload: Payload) => singleton.get(payload) as BillingPlugin | undefined
 
-export const billingPlugin = (pluginConfig: BillingPluginConfig = {}) => (config: Config): Config => {
-  if (pluginConfig.disabled) {
-    return config
-  }
+const disableCollectionBehavior = (collection: CollectionConfig): CollectionConfig => ({
+  ...collection,
+  access: {
+    admin: () => false,
+    create: () => false,
+    delete: () => false,
+    read: () => false,
+    readVersions: () => false,
+    unlock: () => false,
+    update: () => false,
+  },
+  admin: {
+    ...collection.admin,
+    hidden: true,
+  },
+  endpoints: false,
+  hooks: {},
+})
 
-  config.collections = [
-    ...(config.collections || []),
+export const billingPlugin = (pluginConfig: BillingPluginConfig = {}) => (config: Config): Config => {
+  const billingCollections = [
     createPaymentsCollection(pluginConfig),
     createInvoicesCollection(pluginConfig),
     createRefundsCollection(pluginConfig),
-  ];
+  ]
+
+  config.collections = [
+    ...(config.collections || []),
+    ...billingCollections.map(collection => pluginConfig.disabled
+      ? disableCollectionBehavior(collection)
+      : collection),
+  ]
+
+  if (pluginConfig.disabled) {
+    return config
+  }
 
   (pluginConfig.providers || [])
     .filter(provider => provider?.onConfig)


### PR DESCRIPTION
billingPlugin({ disabled: true }) used to return the incoming Payload config unchanged. That meant the payments, invoices, and refunds collections never registered, so a host that disabled the plugin and then ran migrations would lose the billing schema and the data sitting in it.

The plugin now always appends those three collections. When disabled, it then strips collection behavior: every access function returns false, admin.hidden is true, endpoints is false, and hooks is {}. Provider onConfig/onInit and the plugin's own onInit wrapper are skipped, so the consumer's onInit stays the same function object.

The config-transform spec that previously asserted collections.length === 1 (the identity no-op) now asserts the three billing slugs remain, that each still has fields, and that hooks/endpoints are not registered. The onInit identity check is unchanged.

The README Plugin Configuration type now includes disabled?: boolean and states this keep-schema behavior next to it.