### PR TITLE
Names the malformed-body case in the webhook 200-response enumeration, alongside the missing/empty body, unrecognized payment, and failed-signature cases already listed — closing the gap a reviewer found between the README and the four failure paths the branch's own investigation had verified.

### DIFF
--- a/README.md
+++ b/README.md
@@ -951,7 +951,7 @@ const campaignPayments = await payload.find({
 
 Webhook endpoints:
 - Return HTTP 200 for successfully handled events so providers do not retry them
-- Return HTTP 400 only when required data is missing outright (for example, a Stripe request with no `stripe-signature` header); a request whose signature is present but fails verification still returns HTTP 200 with `{ received: false, error: 'Processing error' }`, since no record is touched and the provider should not retry it
+- Return HTTP 400 only when a Stripe request has no `stripe-signature` header; every other failure to process a webhook — a missing or empty body, an unrecognized Mollie payment, or a signature that fails verification — still returns HTTP 200 (`{ received: true }` or `{ received: false, error: 'Processing error' }`), since no record is touched and the provider should not retry it
 - Validate signatures (Stripe) or payment IDs (Mollie)
 - Use optimistic locking to prevent concurrent update conflicts
 - Log detailed errors internally but return generic responses

--- a/README.md
+++ b/README.md
@@ -951,7 +951,7 @@ const campaignPayments = await payload.find({
 
 Webhook endpoints:
 - Return HTTP 200 for successfully handled events so providers do not retry them
-- Return HTTP 400 only when a Stripe request has no `stripe-signature` header; every other failure to process a webhook — a missing or empty body, an unrecognized Mollie payment, or a signature that fails verification — still returns HTTP 200 (`{ received: true }` or `{ received: false, error: 'Processing error' }`), since no record is touched and the provider should not retry it
+- Return HTTP 400 only when a Stripe request has no `stripe-signature` header; every other failure to process a webhook — a missing, empty, or malformed body, an unrecognized Mollie payment, or a signature that fails verification — still returns HTTP 200 (`{ received: true }` or `{ received: false, error: 'Processing error' }`), since no record is touched and the provider should not retry it
 - Validate signatures (Stripe) or payment IDs (Mollie)
 - Use optimistic locking to prevent concurrent update conflicts
 - Log detailed errors internally but return generic responses

--- a/README.md
+++ b/README.md
@@ -984,7 +984,7 @@ type CollectionExtension = string | {
 }
 ```
 
-Setting `disabled: true` returns the host configuration unchanged: no billing collections, endpoints, hooks, or admin views are registered.
+Setting `disabled: true` keeps the billing collection schemas registered to preserve stored billing data, but hides their admin views and skips their hooks, endpoints, and provider wiring.
 
 ### Provider Types
 

--- a/README.md
+++ b/README.md
@@ -950,7 +950,8 @@ const campaignPayments = await payload.find({
 ### Webhook Security
 
 Webhook endpoints:
-- Return HTTP 200 for successfully handled events so providers do not retry them; malformed or unverifiable requests return an error response (for example, Stripe requests without a signature return HTTP 400)
+- Return HTTP 200 for successfully handled events so providers do not retry them
+- Return HTTP 400 only when required data is missing outright (for example, a Stripe request with no `stripe-signature` header); a request whose signature is present but fails verification still returns HTTP 200 with `{ received: false, error: 'Processing error' }`, since no record is touched and the provider should not retry it
 - Validate signatures (Stripe) or payment IDs (Mollie)
 - Use optimistic locking to prevent concurrent update conflicts
 - Log detailed errors internally but return generic responses

--- a/README.md
+++ b/README.md
@@ -135,12 +135,14 @@ import { stripeProvider } from '@xtr-dev/payload-billing'
 
 stripeProvider({
   secretKey: string          // Required: Stripe secret key (sk_test_... or sk_live_...)
-  webhookSecret?: string     // Recommended: Webhook signing secret (whsec_...)
+  webhookSecret?: string     // Required to register the webhook endpoint (whsec_...)
   apiVersion?: string        // Optional: API version (default: '2025-08-27.basil')
   returnUrl?: string         // Optional: Custom return URL after payment
   webhookUrl?: string        // Optional: Custom webhook URL
 })
 ```
+
+Without `webhookSecret`, the Stripe webhook endpoint is not registered. Payments that depend on webhook updates remain `pending`, and requests to the webhook URL return 404.
 
 **Environment Variables:**
 
@@ -207,6 +209,8 @@ testProvider({
   scenarios?: PaymentScenario[]              // Optional: Custom scenarios
   defaultDelay?: number                      // Optional: Default processing delay (ms)
   baseUrl?: string                           // Optional: Server URL
+  customUiRoute?: string                     // Optional: Route for a custom test payment UI
+  returnUrl?: string                         // Optional: Default path after test payment completion
   testModeIndicators?: {
     showWarningBanners?: boolean             // Show test mode warnings
     showTestBadges?: boolean                 // Show test badges on UI
@@ -275,6 +279,25 @@ billingPlugin({
       webhookSecret: process.env.STRIPE_WEBHOOK_SECRET,
     })
   ]
+})
+```
+
+Each collection also accepts an object when you need to rename and extend its Payload collection config:
+
+```typescript
+billingPlugin({
+  collections: {
+    payments: {
+      slug: 'transactions',
+      extend: (config) => ({
+        ...config,
+        fields: [
+          ...config.fields,
+          { name: 'internalReference', type: 'text' },
+        ],
+      }),
+    },
+  },
 })
 ```
 
@@ -388,9 +411,9 @@ billingPlugin({
 
 | Provider | Required Config | Optional Config | Notes |
 |----------|----------------|-----------------|-------|
-| **Stripe** | `secretKey` | `webhookSecret`, `apiVersion`, `returnUrl`, `webhookUrl` | Webhook secret highly recommended for production |
+| **Stripe** | `secretKey` | `webhookSecret`, `apiVersion`, `returnUrl`, `webhookUrl` | `webhookSecret` is required to register the webhook endpoint |
 | **Mollie** | `apiKey` | `webhookUrl`, `redirectUrl` | Requires HTTPS in production |
-| **Test** | `enabled: true` | `scenarios`, `defaultDelay`, `baseUrl`, `testModeIndicators` | Only for development |
+| **Test** | `enabled: true` | `scenarios`, `defaultDelay`, `baseUrl`, `customUiRoute`, `returnUrl`, `testModeIndicators` | Only for development |
 
 ## Collections
 
@@ -476,7 +499,7 @@ Generate and manage invoices with line items and customer information.
 ```typescript
 {
   id: string | number
-  number: string                        // Auto-generated (INV-YYYYMMDD-XXXX)
+  number: string                        // Auto-generated (INV-<millisecond timestamp>)
   customer?: string                     // Customer relationship (if configured)
   customerInfo: {
     name: string
@@ -493,20 +516,19 @@ Generate and manage invoices with line items and customer information.
     postalCode: string
     country: string                     // ISO 3166-1 alpha-2
   }
-  currency: string                      // ISO 4217 currency code
+  currency: string                      // ISO 4217 currency code (defaults to 'USD')
   items: Array<{
     description: string
     quantity: number
     unitAmount: number                  // In cents
-    amount: number                      // Auto-calculated (quantity × unitAmount)
+    totalAmount?: number                // Auto-calculated (quantity × unitAmount)
   }>
   subtotal: number                      // Auto-calculated sum of items
   taxAmount?: number
   amount: number                        // Auto-calculated (subtotal + taxAmount)
   status: 'draft' | 'open' | 'paid' | 'void' | 'uncollectible'
   payment?: Payment | string            // Linked payment
-  dueDate?: string
-  issuedAt?: string
+  dueDate?: string                      // Defaults to 30 days after creation
   paidAt?: string                       // Auto-set when status becomes 'paid'
   notes?: string
   metadata?: Record<string, any>
@@ -525,8 +547,10 @@ draft → open → paid
 
 **Automatic Behaviors:**
 - Invoice number auto-generated on creation
-- Item amounts calculated from quantity × unitAmount
-- Subtotal calculated from sum of item amounts
+- Currency defaults to `USD`
+- Due date defaults to 30 days after creation
+- Item `totalAmount` values calculated from quantity × unitAmount
+- Subtotal calculated from the sum of item `totalAmount` values
 - Total amount calculated as subtotal + taxAmount
 - `paidAt` timestamp set when status becomes 'paid'
 - Linked payment updated when invoice marked as paid
@@ -541,11 +565,11 @@ Track refunds associated with payments.
 ```typescript
 {
   id: string | number
+  providerId: string                    // Required, unique provider refund ID
   payment: Payment | string             // Required: linked payment
-  providerId?: string                   // Provider's refund ID
   amount: number                        // Refund amount in cents
   currency: string                      // ISO 4217 currency code
-  status: 'pending' | 'succeeded' | 'failed' | 'canceled'
+  status: 'pending' | 'processing' | 'succeeded' | 'failed' | 'canceled'
   reason?: 'duplicate' | 'fraudulent' | 'requested_by_customer' | 'other'
   description?: string
   metadata?: Record<string, any>
@@ -556,10 +580,9 @@ Track refunds associated with payments.
 ```
 
 **Automatic Behaviors:**
-- Payment status updated based on refund amount:
-  - Full refund: payment status → `refunded`
-  - Partial refund: payment status → `partially_refunded`
 - Refunds tracked in payment's `refunds` array
+
+Creating a refund record does not submit a refund to the provider or change the payment status. Stripe's verified `charge.refunded` webhook changes the related payment to `refunded` or `partially_refunded`; the Mollie and test providers do not currently perform that status update.
 
 ## Payment Flows
 
@@ -761,6 +784,7 @@ await payload.update({
 const refund = await payload.create({
   collection: 'refunds',
   data: {
+    providerId: 're_provider_refund_id',
     payment: payment.id,
     amount: payment.amount,      // Full amount
     currency: payment.currency,
@@ -769,12 +793,13 @@ const refund = await payload.create({
     description: 'Customer cancelled order'
   }
 })
-// Payment status automatically updated to 'refunded'
+// The payment's refunds relation is updated; its status is unchanged.
 
 // Partial refund
 const partialRefund = await payload.create({
   collection: 'refunds',
   data: {
+    providerId: 're_provider_partial_refund_id',
     payment: payment.id,
     amount: 1000,               // Partial amount ($10.00)
     currency: payment.currency,
@@ -783,7 +808,7 @@ const partialRefund = await payload.create({
     description: 'Partial refund for damaged item'
   }
 })
-// Payment status automatically updated to 'partially_refunded'
+// The payment's refunds relation is updated; its status is unchanged.
 ```
 
 ### Using Customer Relationships
@@ -891,7 +916,7 @@ const campaignPayments = await payload.find({
 
 **Events Handled:**
 - `payment_intent.succeeded` → Updates payment status to `succeeded`
-- `payment_intent.failed` → Updates payment status to `failed`
+- `payment_intent.payment_failed` → Updates payment status to `failed`
 - `payment_intent.canceled` → Updates payment status to `canceled`
 - `charge.refunded` → Updates payment status to `refunded` or `partially_refunded`
 
@@ -924,12 +949,12 @@ const campaignPayments = await payload.find({
 
 ### Webhook Security
 
-All webhook endpoints:
-- Return HTTP 200 OK for all requests (prevents replay attacks)
+Webhook endpoints:
+- Return HTTP 200 for successfully handled events so providers do not retry them; malformed or unverifiable requests return an error response (for example, Stripe requests without a signature return HTTP 400)
 - Validate signatures (Stripe) or payment IDs (Mollie)
 - Use optimistic locking to prevent concurrent update conflicts
 - Log detailed errors internally but return generic responses
-- Run within database transactions for atomicity
+- Use database transactions when the Payload adapter supports them and otherwise fall back to a direct, non-transactional update
 
 ## API Reference
 
@@ -939,14 +964,27 @@ All webhook endpoints:
 type BillingPluginConfig = {
   providers?: PaymentProvider[]
   collections?: {
-    payments?: string
-    invoices?: string
-    refunds?: string
+    payments?: CollectionExtension
+    invoices?: CollectionExtension
+    refunds?: CollectionExtension
   }
   customerRelationSlug?: string
   customerInfoExtractor?: CustomerInfoExtractor
+  disabled?: boolean
+  // Reserved in the current type, but not consumed by the plugin yet:
+  admin?: {
+    customComponents?: boolean
+    dashboard?: boolean
+  }
+}
+
+type CollectionExtension = string | {
+  slug: string
+  extend?: (config: CollectionConfig) => CollectionConfig
 }
 ```
+
+Setting `disabled: true` returns the host configuration unchanged: no billing collections, endpoints, hooks, or admin views are registered.
 
 ### Provider Types
 
@@ -966,8 +1004,11 @@ type StripeProviderConfig = {
   webhookUrl?: string
 }
 
-type MollieProviderConfig = {
-  apiKey: string
+// Options accepted by createMollieClient, including apiKey.
+type MollieProviderConfig = Parameters<typeof createMollieClient>[0]
+
+// mollieProvider additionally accepts:
+type MollieBillingOptions = MollieProviderConfig & {
   webhookUrl?: string
   redirectUrl?: string
 }
@@ -977,6 +1018,8 @@ type TestProviderConfig = {
   scenarios?: PaymentScenario[]
   defaultDelay?: number
   baseUrl?: string
+  customUiRoute?: string
+  returnUrl?: string
   testModeIndicators?: {
     showWarningBanners?: boolean
     showTestBadges?: boolean
@@ -996,7 +1039,7 @@ type CustomerInfoExtractor = (
   phone?: string
   company?: string
   taxId?: string
-  billingAddress: Address
+  billingAddress?: Address
 }
 
 type Address = {
@@ -1024,36 +1067,18 @@ type ProviderData<T = any> = {
 Full TypeScript support with comprehensive type definitions:
 
 ```typescript
+import type { Payload } from 'payload'
 import type {
-  // Main types
   Payment,
   Invoice,
   Refund,
-
-  // Provider types
   PaymentProvider,
   StripeProviderConfig,
   MollieProviderConfig,
   TestProviderConfig,
-
-  // Configuration
   BillingPluginConfig,
   CustomerInfoExtractor,
-
-  // Data types
   ProviderData,
-  Address,
-  InvoiceItem,
-  CustomerInfo,
-
-  // Status types
-  PaymentStatus,
-  InvoiceStatus,
-  RefundStatus,
-  RefundReason,
-
-  // Utility types
-  InitPayment,
   PaymentScenario,
 } from '@xtr-dev/payload-billing'
 
@@ -1069,7 +1094,7 @@ const createPayment = async (
       provider: 'stripe',
       amount,
       currency,
-      status: 'pending' as PaymentStatus
+      status: 'pending'
     }
   })
 }
@@ -1119,6 +1144,8 @@ const createPayment = async (
 ## Troubleshooting
 
 ### Webhook Not Receiving Events
+
+For Stripe, configure `webhookSecret` before testing this URL. Without it, the plugin does not register the endpoint and the URL returns 404.
 
 **Stripe:**
 ```bash

--- a/dev/disabled-plugin.spec.ts
+++ b/dev/disabled-plugin.spec.ts
@@ -11,7 +11,7 @@ describe('billingPlugin disabled configuration', () => {
     const config = {
       collections: [hostCollection],
       onInit: existingOnInit,
-    } as Config
+    } as unknown as Config
 
     const result = billingPlugin({
       disabled: true,
@@ -55,7 +55,7 @@ describe('billingPlugin disabled configuration', () => {
         },
       },
       disabled: true,
-    })({} as Config)
+    })({} as unknown as Config)
 
     const payments = result.collections?.find(collection => collection.slug === 'charges')
     expect(payments?.fields.some(field => 'name' in field && field.name === 'reference')).toBe(true)

--- a/dev/disabled-plugin.spec.ts
+++ b/dev/disabled-plugin.spec.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { CollectionConfig, Config } from 'payload'
+import { billingPlugin } from '../src/plugin/index'
+
+describe('billingPlugin disabled configuration', () => {
+  it('keeps collection schemas while disabling behavior and admin views', () => {
+    const onConfig = vi.fn()
+    const onInit = vi.fn()
+    const existingOnInit = vi.fn()
+    const hostCollection = { slug: 'articles', fields: [] } as CollectionConfig
+    const config = {
+      collections: [hostCollection],
+      onInit: existingOnInit,
+    } as Config
+
+    const result = billingPlugin({
+      disabled: true,
+      providers: [{
+        key: 'disabled-provider',
+        initPayment: vi.fn(),
+        onConfig,
+        onInit,
+      }],
+    })(config)
+
+    expect(result.collections?.[0]).toBe(hostCollection)
+    expect(result.collections?.slice(1).map(collection => collection.slug)).toEqual([
+      'payments',
+      'invoices',
+      'refunds',
+    ])
+
+    for (const collection of result.collections?.slice(1) || []) {
+      expect(collection.fields.length).toBeGreaterThan(0)
+      expect(collection.admin?.hidden).toBe(true)
+      expect(collection.endpoints).toEqual([])
+      expect(collection.hooks).toEqual({})
+    }
+
+    expect(result.onInit).toBe(existingOnInit)
+    expect(onConfig).not.toHaveBeenCalled()
+    expect(onInit).not.toHaveBeenCalled()
+  })
+
+  it('honors collection extensions before disabling their behavior', () => {
+    const result = billingPlugin({
+      collections: {
+        payments: {
+          slug: 'charges',
+          extend: collection => ({
+            ...collection,
+            endpoints: [{ method: 'get', path: '/custom', handler: vi.fn() }],
+            fields: [...collection.fields, { name: 'reference', type: 'text' }],
+          }),
+        },
+      },
+      disabled: true,
+    })({} as Config)
+
+    const payments = result.collections?.find(collection => collection.slug === 'charges')
+    expect(payments?.fields.some(field => 'name' in field && field.name === 'reference')).toBe(true)
+    expect(payments?.endpoints).toEqual([])
+    expect(payments?.hooks).toEqual({})
+    expect(payments?.admin?.hidden).toBe(true)
+  })
+})

--- a/src/collections/invoices.ts
+++ b/src/collections/invoices.ts
@@ -25,7 +25,7 @@ export function createInvoicesCollection(pluginConfig: BillingPluginConfig): Col
       name: 'number',
       type: 'text',
       admin: {
-        description: 'Invoice number (e.g., INV-001)',
+        description: 'Invoice number (e.g., INV-1754737000000)',
       },
       index: true,
       required: true,

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -1,6 +1,6 @@
 import { createInvoicesCollection, createPaymentsCollection, createRefundsCollection } from '../collections/index'
 import type { BillingPluginConfig } from './config'
-import type { Config, Payload } from 'payload'
+import type { CollectionConfig, Config, Payload } from 'payload'
 import { createSingleton } from './singleton'
 import type { PaymentProvider } from '../providers/index'
 
@@ -15,17 +15,33 @@ type BillingPlugin = {
 
 export const useBillingPlugin = (payload: Payload) => singleton.get(payload) as BillingPlugin | undefined
 
-export const billingPlugin = (pluginConfig: BillingPluginConfig = {}) => (config: Config): Config => {
-  if (pluginConfig.disabled) {
-    return config
-  }
+const disableCollectionBehavior = (collection: CollectionConfig): CollectionConfig => ({
+  ...collection,
+  admin: {
+    ...collection.admin,
+    hidden: true,
+  },
+  endpoints: [],
+  hooks: {},
+})
 
-  config.collections = [
-    ...(config.collections || []),
+export const billingPlugin = (pluginConfig: BillingPluginConfig = {}) => (config: Config): Config => {
+  const billingCollections = [
     createPaymentsCollection(pluginConfig),
     createInvoicesCollection(pluginConfig),
     createRefundsCollection(pluginConfig),
-  ];
+  ]
+
+  config.collections = [
+    ...(config.collections || []),
+    ...billingCollections.map(collection => pluginConfig.disabled
+      ? disableCollectionBehavior(collection)
+      : collection),
+  ]
+
+  if (pluginConfig.disabled) {
+    return config
+  }
 
   (pluginConfig.providers || [])
     .filter(provider => provider?.onConfig)


### PR DESCRIPTION
A reviewer pointed out that README.md:954 enumerated three 200-returning webhook failure cases (missing/empty body, unrecognized Mollie payment, failed signature verification) but omitted a fourth case this branch's own prior investigation had already identified: mollie.ts's invalidPayload() response, returned when the webhook body is present but doesn't start with `id=` — distinct from missingBody(), which fires when there's no body at all.

Verified the distinction directly in src/providers/mollie.ts (lines 64-70): missingBody() and invalidPayload() are two separate checks guarding two separate conditions, both returning HTTP 200 via src/providers/utils.ts.

Fix: reworded the line to say "a missing, empty, or malformed body" instead of "a missing or empty body", folding the fourth case in without lengthening the enumeration into an itemized list.