### PR TITLE
Sync Claude workflows with current main so reviews validate and run their permitted checks

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -7,69 +7,50 @@ on:
     # paths:
     #   - "src/**/*.ts"
     #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
 
 jobs:
   claude-review:
     # Only allow bvdaakster to trigger reviews
     if: github.event.pull_request.user.login == 'bvdaakster'
-    
+
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
       id-token: write
-    
+      actions: read # Lets Claude read CI results on the PR
+
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
-          # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4.1)
-          # model: "claude-opus-4-1-20250805"
+          # Providing `prompt` puts the action in automation mode, so no
+          # @claude mention is needed. track_progress posts a tracking comment
+          # that is updated as the review runs.
+          track_progress: true
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
 
-          # Direct prompt for automated review (no @claude mention needed)
-          direct_prompt: |
-            Please review this pull request and provide feedback on:
+            Review this pull request and provide feedback on:
             - Code quality and best practices
             - Potential bugs or issues
             - Performance considerations
-            - Security concerns
+            - Security concerns, especially around payment provider integrations
+              and webhook handling
             - Test coverage
-            
+            - Whether a changeset is needed for user-facing changes
+
             Be constructive and helpful in your feedback.
 
-          # Optional: Use sticky comments to make Claude reuse the same comment on subsequent pushes to the same PR
-          # use_sticky_comment: true
-          
-          # Optional: Customize review based on file types
-          # direct_prompt: |
-          #   Review this PR focusing on:
-          #   - For TypeScript files: Type safety and proper interface usage
-          #   - For API endpoints: Security, input validation, and error handling
-          #   - For React components: Performance, accessibility, and best practices
-          #   - For tests: Coverage, edge cases, and test quality
-          
-          # Optional: Different prompts for different authors
-          # direct_prompt: |
-          #   ${{ github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR' && 
-          #   'Welcome! Please review this PR from a first-time contributor. Be encouraging and provide detailed explanations for any suggestions.' ||
-          #   'Please provide a thorough code review focusing on our coding standards and best practices.' }}
-          
-          # Optional: Add specific tools for running tests or linting
-          # allowed_tools: "Bash(npm run test),Bash(npm run lint),Bash(npm run typecheck)"
-          
-          # Optional: Skip review for certain conditions
-          # if: |
-          #   !contains(github.event.pull_request.title, '[skip-review]') &&
-          #   !contains(github.event.pull_request.title, '[WIP]')
-
+          claude_args: |
+            --allowedTools "Bash(pnpm install),Bash(pnpm lint),Bash(pnpm typecheck),Bash(pnpm test:int)"

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -2,16 +2,21 @@ name: Claude Code Review
 
 on:
   pull_request:
-    types: [opened, synchronize]
-    # Optional: Only run on specific file changes
-    # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
+    types: [opened, synchronize, ready_for_review]
+
+# A new push supersedes the review that is still running for the previous head.
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 jobs:
   claude-review:
-    # Only allow bvdaakster to trigger reviews
-    if: github.event.pull_request.user.login == 'bvdaakster'
+    # Only review PRs opened by the maintainers, and never drafts. The gate used
+    # to name bvdaakster alone, which silently skipped every PR authored by
+    # xtr-bas - i.e. most of them.
+    if: |
+      github.event.pull_request.draft == false &&
+      contains(fromJSON('["bvdaakster", "xtr-bas"]'), github.event.pull_request.user.login)
 
     runs-on: ubuntu-latest
     permissions:
@@ -26,6 +31,20 @@ jobs:
         uses: actions/checkout@v7
         with:
           fetch-depth: 1
+
+      # Without pnpm and node_modules on the runner, the lint/typecheck/test
+      # tools below cannot run and the review is limited to reading the diff.
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
 
       - name: Run Claude Code Review
         id: claude-review
@@ -48,9 +67,16 @@ jobs:
             - Security concerns, especially around payment provider integrations
               and webhook handling
             - Test coverage
-            - Whether a changeset is needed for user-facing changes
+            - Whether the public API in src/index.ts and src/exports/* stays
+              backwards compatible
+            - Whether package.json has a version bump, which PR Version Check
+              requires for every PR to main
+
+            Dependencies are already installed, so you can run pnpm typecheck,
+            pnpm lint and pnpm test to check the branch. Do not run pnpm
+            test:int - it runs vitest in watch mode and hangs in CI.
 
             Be constructive and helpful in your feedback.
 
           claude_args: |
-            --allowedTools "Bash(pnpm install),Bash(pnpm lint),Bash(pnpm typecheck),Bash(pnpm test:int)"
+            --allowedTools "Bash(pnpm lint),Bash(pnpm typecheck),Bash(pnpm test),Bash(pnpm build)"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -30,6 +30,20 @@ jobs:
         with:
           fetch-depth: 1
 
+      # The runner has no pnpm and no node_modules, so without these steps every
+      # pnpm command Claude is allowed to run fails before it starts.
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
       - name: Run Claude Code
         id: claude
         uses: anthropics/claude-code-action@v1
@@ -39,5 +53,5 @@ jobs:
           # Everything else (model, turns, tools, system prompt) goes through
           # claude_args using Claude Code CLI flag syntax.
           claude_args: |
-            --allowedTools "Bash(pnpm install),Bash(pnpm build),Bash(pnpm lint),Bash(pnpm lint:fix),Bash(pnpm typecheck),Bash(pnpm test:int)"
-            --append-system-prompt "This is a PayloadCMS plugin (pnpm + TypeScript). Keep the public API in src/index.ts and src/exports/* stable, add a changeset for user-facing changes, and run pnpm typecheck and pnpm lint before finishing."
+            --allowedTools "Bash(pnpm install),Bash(pnpm build),Bash(pnpm lint),Bash(pnpm lint:fix),Bash(pnpm typecheck),Bash(pnpm test)"
+            --append-system-prompt "This is a PayloadCMS plugin (pnpm + TypeScript); dependencies are already installed on the runner. Keep the public API in src/index.ts and src/exports/* stable. Run pnpm typecheck, pnpm lint and pnpm test before finishing. Note that pnpm test:int runs vitest in watch mode and will hang in CI - use pnpm test instead. Any PR to main must bump the version in package.json, or the PR Version Check workflow fails."

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -19,46 +19,25 @@ jobs:
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pull-requests: read
-      issues: read
+      contents: write
+      pull-requests: write
+      issues: write
       id-token: write
-      actions: read # Required for Claude to read CI results on PRs
+      actions: read # Lets Claude read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
-          # This is an optional setting that allows Claude to read CI results on PRs
-          additional_permissions: |
-            actions: read
-          
-          # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4.1)
-          # model: "claude-opus-4-1-20250805"
-          
-          # Optional: Customize the trigger phrase (default: @claude)
-          # trigger_phrase: "/claude"
-          
-          # Optional: Trigger when specific user is assigned to an issue
-          # assignee_trigger: "claude-bot"
-          
-          # Optional: Allow Claude to run specific commands
-          # allowed_tools: "Bash(npm install),Bash(npm run build),Bash(npm run test:*),Bash(npm run lint:*)"
-          
-          # Optional: Add custom instructions for Claude to customize its behavior for your project
-          # custom_instructions: |
-          #   Follow our coding standards
-          #   Ensure all new code has tests
-          #   Use TypeScript for new files
-          
-          # Optional: Custom environment variables for Claude
-          # claude_env: |
-          #   NODE_ENV: test
-
+          # Everything else (model, turns, tools, system prompt) goes through
+          # claude_args using Claude Code CLI flag syntax.
+          claude_args: |
+            --allowedTools "Bash(pnpm install),Bash(pnpm build),Bash(pnpm lint),Bash(pnpm lint:fix),Bash(pnpm typecheck),Bash(pnpm test:int)"
+            --append-system-prompt "This is a PayloadCMS plugin (pnpm + TypeScript). Keep the public API in src/index.ts and src/exports/* stable, add a changeset for user-facing changes, and run pnpm typecheck and pnpm lint before finishing."


### PR DESCRIPTION
The earlier workflow update copied the version that main had before PR #38. This refresh makes both Claude workflow files byte-identical to the current default branch, as required by claude-code-action@v1 validation. It retains the non-draft maintainer gate for both accounts, installs pnpm dependencies before Claude runs tools, and permits pnpm test instead of watch-mode pnpm test:int. No package version change is included because this is CI configuration only.